### PR TITLE
Fix/cache and new commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formidablejs/craftsman",
-  "version": "0.0.1-rc3",
+  "version": "0.0.1-rc4",
   "author": "Donald Pakkies <donaldpakkies@gmail.com>",
   "bin": {
     "craftsman": "./bin/run"

--- a/src/commands/cache.js
+++ b/src/commands/cache.js
@@ -10,11 +10,11 @@ class CacheCommand extends Command {
 
     cli.action.start('Caching');
 
-    cache(1, flags.debug);
+    cache(flags.debug);
   }
 }
 
-const cache = (tick = 1, debug) => {
+const cache = (debug) => {
   const output = path.join(process.cwd(), 'node_modules', '.cache', 'formidable')
 
   const command = `node node_modules/.bin/imba build server.cli.imba --outdir=${output} --clean`
@@ -28,10 +28,8 @@ const cache = (tick = 1, debug) => {
       await Application.then((app) => {
         fs.rmSync(output, { recursive: true });
 
-        if (tick === 1) {
-          cache(2, debug);
-
-          return;
+        if (typeof app.cache == 'function') {
+          app.cache();
         }
 
         cli.action.stop();

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -108,7 +108,7 @@ class NewCommand extends Command {
         flags.manager = res.manager;
       }
 
-      cli.action.start('Installation in progress, this may take a while ☕');
+      cli.action.start('Installation in progress. This might take a while ☕');
 
       installDependencies(flags.manager, location, args.name)
     }).catch(() => {
@@ -124,27 +124,19 @@ const installDependencies = (manager, location, name) => {
     cwd: location
   });
 
-  let failed = false;
-
   install.stderr.on('data', (data) => {
-    failed = true;
+    cli.action.stop('Failed');
+
+    fs.rmSync(location, {
+      recursive: true
+    });
 
     console.error(data);
+
+    console.log(chalk.red('REMOVE ') + location);
   });
 
   install.on('exit', () => {
-    if (failed) {
-      cli.action.stop('Failed');
-
-      fs.rmSync(location, {
-        recursive: true
-      });
-
-      console.log(chalk.red('REMOVE ') + location);
-
-      return;
-    }
-
     publishEmails(manager, location, name);
   });
 }


### PR DESCRIPTION
A cleaner way of caching application config's.

> We no longer need to run the `cache` function twice (ticks) 