### PR TITLE
feat(maintenance): added a redirect flag

### DIFF
--- a/src/commands/down.js
+++ b/src/commands/down.js
@@ -19,6 +19,10 @@ class DownCommand extends Command {
       downObject.message = flags.message;
     }
 
+    if (flags.redirect) {
+      downObject.redirect = flags.redirect;
+    }
+
     if (flags.retry) {
       downObject.retry = flags.retry;
     }
@@ -55,6 +59,7 @@ DownCommand.flags = {
   refresh: flags.integer({ description: 'The number of seconds after which the browser may refresh' }),
   secret: flags.string({ description: 'The secret phrase that may be used to bypass maintenance mode' }),
   status: flags.integer({ description: 'The status code that should be used when returning the maintenance mode response', default: 503 }),
+  redirect: flags.string({ description: 'The URL to which the browser should be redirected' }),
 }
 
 module.exports = DownCommand;


### PR DESCRIPTION
<!-- This is adapted from github.com/imba/imba -->

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Added a `--redirect` flag in the `down` command.

This flag allows a formidable application to know the location of the maintenance mode page.

## How Has This Been Tested?

1. `cd` into a dummy project.
2. `./<craftsman-location>/bin/run down --redirect="maintenance"`

<!-- Please describe in detail how you tested your changes. -->

<!-- Include details of your testing environment, tests ran to see how -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
